### PR TITLE
add timestamp into coinbase tx input's script

### DIFF
--- a/src/Stratum.cc
+++ b/src/Stratum.cc
@@ -402,12 +402,21 @@ bool StratumJob::initFromGbt(const char *gbt, const string &poolCoinbaseInfo,
   {
     CTxIn cbIn;
     //
-    // block height, 4 bytes
+    // block height, 4 bytes in script: 0x03xxxxxx
     // https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
     // https://github.com/bitcoin/bitcoin/pull/1526
     //
     cbIn.scriptSig = CScript();
     cbIn.scriptSig << (uint32_t)height_;
+
+    // add current timestamp to coinbase tx input, so if the block's merkle root
+    // hash is the same, there's no risk for miners to calc the same space.
+    // https://github.com/btccom/btcpool/issues/5
+    //
+    // 5 bytes in script: 0x04xxxxxxxx.
+    // eg. 0x0402363d58 -> 0x583d3602 = 1480406530 = 2016-11-29 16:02:10
+    //
+    cbIn.scriptSig << CScriptNum((uint32_t)time(nullptr));
 
     // pool's info
     cbIn.scriptSig.insert(cbIn.scriptSig.end(),

--- a/test/TestStratum.cc
+++ b/test/TestStratum.cc
@@ -192,8 +192,16 @@ TEST(Stratum, StratumJob) {
     ASSERT_EQ(sjob2.prevHash_, uint256S("000000004f2ea239532b2e77bb46c03b86643caac3fe92959a31fd2d03979c34"));
     ASSERT_EQ(sjob2.prevHashBeStr_, "03979c349a31fd2dc3fe929586643caabb46c03b532b2e774f2ea23900000000");
     ASSERT_EQ(sjob2.height_, 898487);
-    ASSERT_EQ(sjob2.coinbase1_,
-              "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1903b7b50d2f4254432e434f4d2f");
+    // 46 bytes, 5 bytes (timestamp), 9 bytes (poolCoinbaseInfo)
+    // 01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1e03b7b50d 0402363d58 2f4254432e434f4d2f
+    ASSERT_EQ(sjob2.coinbase1_.substr(0, 92),
+              "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1e03b7b50d");
+    ASSERT_EQ(sjob2.coinbase1_.substr(102, 18), "2f4254432e434f4d2f");
+    // 0402363d58 -> 0x583d3602 = 1480406530 = 2016-11-29 16:02:10
+    uint32_t ts = (uint32_t)strtoull(sjob2.coinbase1_.substr(94, 8).c_str(), nullptr, 16);
+    ts = HToBe(ts);
+    ASSERT_EQ(ts == time(nullptr) || ts + 1 == time(nullptr), true);
+
     ASSERT_EQ(sjob2.coinbase2_,
               "ffffffff01c7cea212000000001976a914ca560088c0fb5e6f028faa11085e643e343a8f5c88ac00000000");
     ASSERT_EQ(sjob2.merkleBranch_.size(), 1);


### PR DESCRIPTION
fix issue: https://github.com/btccom/btcpool/issues/5.

If `merkle root hash` is the same between different jobs, could have duplicate share attack in some condition. For bitcoin it's very hard to do the attack but for altcoin it's much easier.

So we just put current timestamp into coinbase tx input's script.