### PR TITLE
fix issue: https://github.com/btccom/btcpool/issues/7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,51 +75,51 @@ execute_process(COMMAND mysql_config --libs_r OUTPUT_VARIABLE MYSQL_LIB OUTPUT_S
 execute_process(COMMAND mysql_config --include OUTPUT_VARIABLE MYSQL_INCLUDE OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 include_directories(src test src/bitcoin src/bitcoin/secp256k1/include ${OPENSSL_INCLUDE_DIR} ${Boost_INCLUDE_DIRS} ${LIBZMQ_INCLUDE_DIR} ${GLOG_INCLUDE_DIRS} ${LIBEVENT_INCLUDE_DIR} ${MYSQL_INCLUDE})
-set(THRID_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY} ${Boost_LIBRARIES} ${LIBCONFIGPP_LIBRARY} ${LIBZMQ_LIBRARIES} ${GLOG_LIBRARIES} ${CURL_LIBRARIES} ${KAFKA_LIBRARIES} ${LIBEVENT_LIB} ${LIBEVENT_PTHREADS_LIB} ${secp256k1_LIBRARIES} pthread mysqlclient)
+set(THIRD_LIBRARIES ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY} ${Boost_LIBRARIES} ${LIBCONFIGPP_LIBRARY} ${LIBZMQ_LIBRARIES} ${GLOG_LIBRARIES} ${CURL_LIBRARIES} ${KAFKA_LIBRARIES} ${LIBEVENT_LIB} ${LIBEVENT_PTHREADS_LIB} ${secp256k1_LIBRARIES} pthread mysqlclient gmp)
 
 file(GLOB LIB_SOURCES src/*.cc src/bitcoin/*.cpp src/bitcoin/consensus/*.cpp src/bitcoin/crypto/*.cpp src/bitcoin/primitives/*.cpp src/bitcoin/script/*.cpp src/bitcoin/support/*.cpp)
 add_library(btcpool STATIC ${LIB_SOURCES})
 
 file(GLOB_RECURSE TEST_SOURCES test/*.cc)
 add_executable(unittest ${TEST_SOURCES})
-target_link_libraries(unittest btcpool ${THRID_LIBRARIES})
+target_link_libraries(unittest btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE GBTMAKER_SOURCES src/gbtmaker/*.cc)
 add_executable(gbtmaker ${GBTMAKER_SOURCES})
-target_link_libraries(gbtmaker btcpool ${THRID_LIBRARIES})
+target_link_libraries(gbtmaker btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE NMC_AUXBLOCK_MAKER_SOURCES src/nmcauxmaker/*.cc)
 add_executable(nmcauxmaker ${NMC_AUXBLOCK_MAKER_SOURCES})
-target_link_libraries(nmcauxmaker btcpool ${THRID_LIBRARIES})
+target_link_libraries(nmcauxmaker btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE JOBMAKER_SOURCES src/jobmaker/*.cc)
 add_executable(jobmaker ${JOBMAKER_SOURCES})
-target_link_libraries(jobmaker btcpool ${THRID_LIBRARIES})
+target_link_libraries(jobmaker btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE SSERVER_SOURCES src/sserver/*.cc)
 add_executable(sserver ${SSERVER_SOURCES})
-target_link_libraries(sserver btcpool ${THRID_LIBRARIES})
+target_link_libraries(sserver btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE STATSHTTPD_SOURCES src/statshttpd/*.cc)
 add_executable(statshttpd ${STATSHTTPD_SOURCES})
-target_link_libraries(statshttpd btcpool ${THRID_LIBRARIES})
+target_link_libraries(statshttpd btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE SHARELOGGER_SOURCES src/sharelogger/*.cc)
 add_executable(sharelogger ${SHARELOGGER_SOURCES})
-target_link_libraries(sharelogger btcpool ${THRID_LIBRARIES})
+target_link_libraries(sharelogger btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE SLPARSER_SOURCES src/slparser/*.cc)
 add_executable(slparser ${SLPARSER_SOURCES})
-target_link_libraries(slparser btcpool ${THRID_LIBRARIES})
+target_link_libraries(slparser btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE BLKMAKER_SOURCES src/blkmaker/*.cc)
 add_executable(blkmaker ${BLKMAKER_SOURCES})
-target_link_libraries(blkmaker btcpool ${THRID_LIBRARIES})
+target_link_libraries(blkmaker btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE SIMULATOR_SOURCES src/simulator/*.cc)
 add_executable(simulator ${SIMULATOR_SOURCES})
-target_link_libraries(simulator btcpool ${THRID_LIBRARIES})
+target_link_libraries(simulator btcpool ${THIRD_LIBRARIES})
 
 file(GLOB_RECURSE POOLWATCHER_SOURCES src/poolwatcher/*.cc)
 add_executable(poolwatcher ${POOLWATCHER_SOURCES})
-target_link_libraries(poolwatcher btcpool ${THRID_LIBRARIES})
+target_link_libraries(poolwatcher btcpool ${THIRD_LIBRARIES})

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,7 @@ Install BTC.COM Pool
 =====================
 
 * OS: `Ubuntu 14.04 LTS, 64 Bits`
+* OS: `Ubuntu 16.04 LTS, 64 Bits`
 
 ## Build
 
@@ -19,7 +20,7 @@ bash ./install_btcpool.sh
 apt-get update
 
 apt-get install -y build-essential autotools-dev libtool autoconf automake pkg-config cmake
-apt-get install -y openssl libssl-dev libcurl4-openssl-dev libconfig++-dev libboost-all-dev libmysqlclient-dev
+apt-get install -y openssl libssl-dev libcurl4-openssl-dev libconfig++-dev libboost-all-dev libgmp-dev libmysqlclient-dev
 ```
 
 * zmq-v4.1.5


### PR DESCRIPTION
fix issue: https://github.com/btccom/btcpool/issues/7

- fixed typo in CMakeLists.txt: THRID_LIBRARIES => THIRD_LIBRARIES
- add link to `libgmp`, seems Ubuntu 14.04.5 LTS or 16.04 has the link problem

thanks to @dyzz.
