### PR TITLE
life time for removing empty gbt from buffer

### DIFF
--- a/src/JobMaker.cc
+++ b/src/JobMaker.cc
@@ -304,6 +304,7 @@ void JobMaker::addRawgbt(const char *str, size_t len) {
   }
   assert(nodeGbt["result"]["height"].type() == Utilities::JS::type::Int);
   const uint32_t height = nodeGbt["result"]["height"].uint32();
+  assert(height < 0x7FFFFFFFU);
   const uint64_t emptyFlag = nodeGbt["result"]["transactions"].array().size() == 0 ? 0x80000000ULL : 0;
 
   {

--- a/src/JobMaker.cc
+++ b/src/JobMaker.cc
@@ -386,11 +386,10 @@ void JobMaker::sendStratumJob(const char *gbt) {
 void JobMaker::findNewBestHeight(std::map<uint64_t/* height + ts */, const char *> *gbtByHeight) {
   for (const auto &itr : rawgbtMap_) {
     const uint32_t timestamp = (uint32_t)((itr.first >> 32) & 0x00000000FFFFFFFFULL);
-    const uint32_t emptyFlag = (uint32_t)(itr.first         & 0x0000000080000000ULL);
     const uint32_t height    = (uint32_t)(itr.first         & 0x000000007FFFFFFFULL);
 
-    // using Map to sort by: height + emptyFlag + timestamp
-    const uint64_t key = ((uint64_t)height << 32) + (uint64_t)emptyFlag + (uint64_t)timestamp;
+    // using Map to sort by: height + timestamp
+    const uint64_t key = ((uint64_t)height << 32) + (uint64_t)timestamp;
     gbtByHeight->insert(std::make_pair(key, itr.second.c_str()));
   }
 }

--- a/src/JobMaker.h
+++ b/src/JobMaker.h
@@ -56,6 +56,7 @@ class JobMaker {
   CBitcoinAddress poolPayoutAddr_;
 
   uint32_t kGbtLifeTime_;
+  uint32_t kEmptyGbtLifeTime_;
   string fileLastJobTime_;
 
   std::map<uint64_t/* timestamp + height */, string> rawgbtMap_;  // sorted gbt by timestamp
@@ -80,7 +81,7 @@ class JobMaker {
 public:
   JobMaker(const string &kafkaBrokers, uint32_t stratumJobInterval,
            const string &payoutAddr, uint32_t gbtLifeTime,
-           const string &fileLastJobTime);
+           uint32_t emptyGbtLifeTime, const string &fileLastJobTime);
   ~JobMaker();
 
   bool init();

--- a/src/jobmaker/JobMakerMain.cc
+++ b/src/jobmaker/JobMakerMain.cc
@@ -143,14 +143,15 @@ int main(int argc, char **argv) {
     }
 
     string fileLastJobTime;
-    uint32_t stratumJobInterval, gbtLifeTime;
+    uint32_t stratumJobInterval, gbtLifeTime, emptyGbtLifeTime;
     cfg.lookupValue("jobmaker.stratum_job_interval", stratumJobInterval);
     cfg.lookupValue("jobmaker.gbt_life_time", gbtLifeTime);
+    cfg.lookupValue("jobmaker.empty_gbt_life_time", emptyGbtLifeTime);
     cfg.lookupValue("jobmaker.file_last_job_time", fileLastJobTime);
 
     gJobMaker = new JobMaker(cfg.lookup("kafka.brokers"), stratumJobInterval,
                              cfg.lookup("pool.payout_address"), gbtLifeTime,
-                             fileLastJobTime);
+                             emptyGbtLifeTime, fileLastJobTime);
 
     if (!gJobMaker->init()) {
       LOG(FATAL) << "init failure";

--- a/src/jobmaker/jobmaker.cfg
+++ b/src/jobmaker/jobmaker.cfg
@@ -16,6 +16,8 @@ jobmaker = {
   gbt_life_time = 60;
 
   # max empty gbt life cycle time seconds
+  # CAUTION: the value SHOULD >= 10. If non-empty job not come in 10 seconds, 
+  #          jobmaker will always make a previous height job until its arrival 
   empty_gbt_life_time = 15;
 
   # write last stratum job send time to file

--- a/src/jobmaker/jobmaker.cfg
+++ b/src/jobmaker/jobmaker.cfg
@@ -15,6 +15,9 @@ jobmaker = {
   # max gbt life cycle time seconds
   gbt_life_time = 60;
 
+  # max empty gbt life cycle time seconds
+  empty_gbt_life_time = 15;
+
   # write last stratum job send time to file
   file_last_job_time = "/work/xxx/jobmaker_lastjobtime.txt";
 };


### PR DESCRIPTION
- This PR makes empty gbt life time configurable. And when is expired, remove it from raw gbt buffer.
- In some cases, the block height may roll back. When it happens, this patch could make a shorter empty job period to switch back to the previous block height job. 
- Former rawgbtMap's 64-bit key is combined by 'timestamp' and 'height'. Now I use the msb of the lower 32 bits of key (mask: 0x0000000080000000) to indicate the raw gbt whether is empty. As bitcoin blockchain generates 210000 for every 4 years, then 2147483648( 2^31) will be met after over 40000 years. So it is safe for us to use.


