### PR TITLE
add heartbeat files for statshttpd and nmcauxblocker; a new heartbeat script for namecoind

### DIFF
--- a/docker/namecoind/v0.13.0rc1/crontab.txt
+++ b/docker/namecoind/v0.13.0rc1/crontab.txt
@@ -1,6 +1,6 @@
 SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-* * * * *   root bash /root/scripts/bitmain-monitor-namecoind.sh > /dev/null 2>&1
-*/5 * * * * root bash /root/scripts/watch-namecoind.sh           > /dev/null 2>&1
+* * * * *   root bash /root/scripts/opsgenie-monitor-namecoind.sh > /dev/null 2>&1
+*/5 * * * * root bash /root/scripts/watch-namecoind.sh            > /dev/null 2>&1
 

--- a/docker/namecoind/v0.13.0rc1/opsgenie-monitor-namecoind.sh
+++ b/docker/namecoind/v0.13.0rc1/opsgenie-monitor-namecoind.sh
@@ -3,26 +3,39 @@
 # namecoind monitor shell
 #
 # @copyright btc.com
-# @author Zhibiao Pan
+# @author Zhibiao Pan, Yihao Peng
 # @since 2016-09
 #
 SROOT=$(cd $(dirname "$0"); pwd)
 cd $SROOT
 
+
+# the name of https://app.opsgenie.com/heartbeat
+SERVICE="namecoind.01"
+
+# api key of opsgenie
+API_KEY="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+# api endpoint
+MURL="https://api.opsgenie.com/v1/json/heartbeat/send"
+
+
 NAMECOIND_RPC="namecoin-cli "
 #WANIP=`ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/'`
 #WANIP=`curl https://api.ipify.org`
-WANIP=`curl http://ipinfo.io/ip`
+#WANIP=`curl http://ipinfo.io/ip`
 
 #NOERROR=`$NAMECOIND_RPC getinfo |  grep '"errors" : ""' | wc -l`
 HEIGHT=`$NAMECOIND_RPC getinfo | grep "blocks" | awk '{print $2}' | awk -F"," '{print $1}'`
 CONNS=`$NAMECOIND_RPC getinfo | grep "connections" | awk '{print $2}' | awk -F"," '{print $1}'`
 
-SERVICE="bpool.namecoind.$WANIP"
-VALUE="height:$HEIGHT;conn:$CONNS;"
-MURL="http://monitor.bitmain.com/monitor/api/v1/message?service=$SERVICE&value=$VALUE"
+#VALUE="height:$HEIGHT;conn:$CONNS;"
+
+DATA=`cat << EOF
+{"apiKey":"$API_KEY","name":"$SERVICE"}
+EOF`
 
 if [[ $CONNS -ne 0 ]]; then
-  curl --max-time 30 $MURL
+  curl -XPOST --max-time 30 $MURL -d "$DATA"
   exit 0
 fi

--- a/src/GbtMaker.cc
+++ b/src/GbtMaker.cc
@@ -294,11 +294,13 @@ NMCAuxBlockMaker::NMCAuxBlockMaker(const string &zmqNamecoindAddr,
                                    const string &rpcUserpass,
                                    const string &kafkaBrokers,
                                    uint32_t kRpcCallInterval,
+                                   string fileLastRpcCallTime,
                                    bool isCheckZmq) :
 running_(true), zmqContext_(1/*i/o threads*/),
 zmqNamecoindAddr_(zmqNamecoindAddr),
 rpcAddr_(rpcAddr), rpcUserpass_(rpcUserpass),
 lastCallTime_(0), kRpcCallInterval_(kRpcCallInterval),
+fileLastRpcCallTime_(fileLastRpcCallTime),
 kafkaBrokers_(kafkaBrokers),
 kafkaProducer_(kafkaBrokers_.c_str(), KAFKA_TOPIC_NMC_AUXBLOCK, 0/* partition */),
 isCheckZmq_(isCheckZmq)
@@ -431,6 +433,11 @@ void NMCAuxBlockMaker::submitAuxblockMsg(bool checkTime) {
   // submit to Kafka
   LOG(INFO) << "sumbit to Kafka, msg len: " << auxMsg.length();
   kafkaProduceMsg(auxMsg.c_str(), auxMsg.length());
+
+  // save the timestamp to file, for monitor system
+  if (!fileLastRpcCallTime_.empty()) {
+  	writeTime2File(fileLastRpcCallTime_.c_str(), lastCallTime_);
+  }
 }
 
 void NMCAuxBlockMaker::threadListenNamecoind() {

--- a/src/GbtMaker.h
+++ b/src/GbtMaker.h
@@ -85,6 +85,7 @@ class NMCAuxBlockMaker {
   string rpcUserpass_;
   atomic<uint32_t> lastCallTime_;
   uint32_t kRpcCallInterval_;
+  string fileLastRpcCallTime_;
 
   string kafkaBrokers_;
   KafkaProducer kafkaProducer_;
@@ -103,7 +104,7 @@ public:
   NMCAuxBlockMaker(const string &zmqNamecoindAddr,
                    const string &rpcAddr, const string &rpcUserpass,
                    const string &kafkaBrokers, uint32_t kRpcCallInterval,
-                   bool isCheckZmq);
+                   string fileLastRpcCallTime, bool isCheckZmq);
   ~NMCAuxBlockMaker();
 
   bool init();

--- a/src/Statistics.h
+++ b/src/Statistics.h
@@ -269,6 +269,8 @@ class StatsServer {
   MySQLConnection  poolDB_;      // flush workers to table.mining_workers
   time_t kFlushDBInterval_;
   atomic<bool> isInserting_;     // flag mark if we are flushing db
+  
+  string fileLastFlushTime_;     // write last db flush time to the file
 
   // httpd
   struct event_base *base_;
@@ -297,7 +299,7 @@ public:
 public:
   StatsServer(const char *kafkaBrokers, const string &httpdHost,
               unsigned short httpdPort, const MysqlConnectInfo &poolDBInfo,
-              const time_t kFlushDBInterval);
+              const time_t kFlushDBInterval, const string &fileLastFlushTime);
   ~StatsServer();
 
   bool init();

--- a/src/nmcauxmaker/NMCAuxBlockMakerMain.cc
+++ b/src/nmcauxmaker/NMCAuxBlockMakerMain.cc
@@ -116,12 +116,15 @@ int main(int argc, char **argv) {
   cfg.lookupValue("nmcauxmaker.is_check_zmq", isCheckZmq);
   int32_t rpcCallInterval = 5;
   cfg.lookupValue("nmcauxmaker.rpcinterval", rpcCallInterval);
+  string fileLastRpcCallTime;
+  cfg.lookupValue("nmcauxmaker.file_last_rpc_call_time", fileLastRpcCallTime);
 
   gNMCAuxBlockMaker = new NMCAuxBlockMaker(cfg.lookup("namecoind.zmq_addr"),
                                            cfg.lookup("namecoind.rpc_addr"),
                                            cfg.lookup("namecoind.rpc_userpwd"),
                                            cfg.lookup("kafka.brokers"),
-                                           rpcCallInterval, isCheckZmq);
+                                           rpcCallInterval, fileLastRpcCallTime,
+                                           isCheckZmq);
 
   try {
     if (!gNMCAuxBlockMaker->init()) {

--- a/src/nmcauxmaker/nmcauxmaker.cfg
+++ b/src/nmcauxmaker/nmcauxmaker.cfg
@@ -8,6 +8,8 @@
 nmcauxmaker = {
   // rpc call interval seconds
   rpcinterval = 10;
+  // write last rpc call time to file
+  file_last_rpc_call_time = "/work/xxx/nmcauxmaker_lastrpccalltime.txt";
 
   // check zmq when startup
   is_check_zmq = true;

--- a/src/statshttpd/StatsHttpdMain.cc
+++ b/src/statshttpd/StatsHttpdMain.cc
@@ -122,15 +122,18 @@ int main(int argc, char **argv) {
                                         cfg.lookup("pooldb.password"),
                                         cfg.lookup("pooldb.dbname"));
     }
+    
+    string fileLastFlushTime;
 
     int32_t port = 8080;
     int32_t flushInterval = 20;
     cfg.lookupValue("statshttpd.port", port);
     cfg.lookupValue("statshttpd.flush_db_interval", flushInterval);
+    cfg.lookupValue("statshttpd.file_last_flush_time",   fileLastFlushTime);
     gStatsServer = new StatsServer(cfg.lookup("kafka.brokers").c_str(),
                                    cfg.lookup("statshttpd.ip").c_str(),
                                    (unsigned short)port, *poolDBInfo,
-                                   (time_t)flushInterval);
+                                   (time_t)flushInterval, fileLastFlushTime);
     if (gStatsServer->init()) {
     	gStatsServer->run();
     }

--- a/src/statshttpd/statshttpd.cfg
+++ b/src/statshttpd/statshttpd.cfg
@@ -18,6 +18,8 @@ statshttpd = {
   # merge table when flush data to DB. we have test mysql, it could flush
   # 25,000 workers into DB in about 1.7 seconds.
   flush_db_interval = 15;
+  # write last db flush time to file
+  file_last_flush_time = "/work/xxx/statshttpd_lastflushtime.txt";
 };
 
 


### PR DESCRIPTION
1. Add heartbeat files for `statshttpd` and `nmcauxblocker`, likes `file_last_job_time` of `jobmaker`.
2. A new heartbeat script `opsgenie-monitor-namecoind.sh` for namecoind's docker. Original `bitmain-monitor-namecoind.sh` has removed.