### PR TITLE
[merged mining] add new nmc rpc commands

### DIFF
--- a/docker/namecoind/btccom-v0.1-beta/Dockerfile
+++ b/docker/namecoind/btccom-v0.1-beta/Dockerfile
@@ -1,0 +1,58 @@
+#
+# Dockerfile
+#
+# @author zhibiao.pan@bitmain.com
+# @copyright btc.com
+# @since 2016-08-01
+#
+#
+FROM phusion/baseimage:0.9.19
+MAINTAINER PanZhibiao <zhibiao.pan@bitmain.com>
+
+ENV HOME /root
+ENV TERM xterm
+CMD ["/sbin/my_init"]
+
+# use aliyun source
+#ADD sources-aliyun.com.list /etc/apt/sources.list
+
+RUN apt-get update
+RUN apt-get install -y build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils yasm
+RUN apt-get install -y libboost-all-dev libzmq3-dev curl wget
+
+# download namecoind
+RUN mkdir ~/source
+RUN cd ~/source && wget https://github.com/btccom/namecoin-core/archive/btccom-v0.1-beta.tar.gz -O btccom-v0.1-beta.tar.gz \
+  && tar zxf btccom-v0.1-beta.tar.gz
+
+# build namecoind
+RUN cd ~/source/namecoin-core-btccom-v0.1-beta \
+  && ./autogen.sh \
+  && ./configure --disable-wallet --without-miniupnpc --disable-tests \
+  && make && make install
+  #&& make -j$(nproc) && make install
+
+# mkdir namecoind data dir
+RUN mkdir -p /root/.namecoin
+RUN mkdir -p /root/scripts
+
+# scripts
+ADD opsgenie-monitor-namecoind.sh  /root/scripts/opsgenie-monitor-namecoind.sh
+ADD watch-namecoind.sh             /root/scripts/watch-namecoind.sh
+
+# crontab shell
+ADD crontab.txt /etc/cron.d/namecoind
+
+# logrotate
+ADD logrotate-namecoind /etc/logrotate.d/namecoind
+
+# services
+RUN mkdir /etc/service/namecoind
+ADD run /etc/service/namecoind/run
+RUN chmod +x /etc/service/namecoind/run
+
+# remove source & build files
+RUN rm -rf ~/source
+
+# clean
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/namecoind/btccom-v0.1-beta/README.md
+++ b/docker/namecoind/btccom-v0.1-beta/README.md
@@ -1,0 +1,111 @@
+Docker for Namecoind btccom-v0.1-beta
+============================
+
+* OS: `Ubuntu 14.04 LTS`
+* Docker Image OS: `Ubuntu 16.04 LTS`
+* Namecoind: `btccom-v0.1-beta`
+
+## Install Docker
+
+```
+# Use 'curl -sSL https://get.daocloud.io/docker | sh' instead of this line
+# when your server is in China.
+wget -qO- https://get.docker.com/ | sh
+
+service docker start
+service docker status
+```
+
+## Build Docker Images
+
+```
+cd /work
+
+git clone https://github.com/btccom/btcpool.git
+cd btcpool/docker/namecoind/btccom-v0.1-beta
+
+# If your server is in China, please check "Dockerfile" and uncomment some lines
+
+# build
+docker build -t namecoind:btccom-v0.1-beta .
+# docker build --no-cache -t namecoind:btccom-v0.1-beta .
+
+# mkdir for namecoind
+mkdir -p /work/namecoind
+
+# namecoin.conf
+touch /work/namecoind/namecoin.conf
+```
+
+### namecoin.conf example
+
+```
+rpcuser=namecoinrpc
+# generate random rpc password:
+#   $ strings /dev/urandom | grep -o '[[:alnum:]]' | head -n 30 | tr -d '\n'; echo
+rpcpassword=xxxxxxxxxxxxxxxxxxxxxxxxxx
+rpcthreads=4
+
+rpcallowip=172.16.0.0/12
+rpcallowip=192.168.0.0/16
+rpcallowip=10.0.0.0/8
+
+# we use ZMQ to get notification when new block is coming
+zmqpubrawblock=tcp://0.0.0.0:8337
+zmqpubrawtx=tcp://0.0.0.0:8337
+zmqpubhashtx=tcp://0.0.0.0:8337
+zmqpubhashblock=tcp://0.0.0.0:8337
+
+# use 1MB block when call GBT
+blockmaxsize=1000000
+```
+
+## Start Docker Container
+
+```
+# start docker
+docker run -it -v /work/namecoind:/root/.namecoin --name namecoind -p 8334:8334 -p 8336:8336 -p 8337:8337 --restart always -d namecoind:btccom-v0.1-beta
+
+# login
+docker exec -it namecoind /bin/bash
+```
+
+## Service Monitor
+
+There are two cron jobs in docker by default. Editing or deleting it by your want:
+
+```bash
+$ docker exec -it namecoind /bin/bash
+$ vim /etc/cron.d/namecoind
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+* * * * *   root bash /root/scripts/opsgenie-monitor-namecoind.sh > /dev/null 2>&1
+*/5 * * * * root bash /root/scripts/watch-namecoind.sh            > /dev/null 2>&1
+```
+
+### `opsgenie-monitor-namecoind.sh`
+
+It provides a monitor service with heartbeats of opsgenie.
+
+Setting `SERVICE` and `API_KEY` are necessary before it works.
+
+```bash
+$ vim /root/scripts/opsgenie-monitor-namecoind.sh
+...
+
+# the name of https://app.opsgenie.com/heartbeat
+SERVICE="namecoind.01"
+
+# api key of opsgenie
+API_KEY="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+...
+```
+
+### `watch-namecoind.sh`
+It calls `namecoin-cli getauxblock` and while the result is error/unexpected, it calls `namecoin-cli stop`. Then namecoind will be auto restarted by it's daemon.
+
+By default, the script runs per 5 minutes. Maybe we should disable it at the block-synchronization stage of namecoind, or it will be restarted regularly per 5 minutes and gearing down the speed of block-downloading.
+
+

--- a/docker/namecoind/btccom-v0.1-beta/crontab.txt
+++ b/docker/namecoind/btccom-v0.1-beta/crontab.txt
@@ -1,0 +1,6 @@
+SHELL=/bin/sh
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+* * * * *   root bash /root/scripts/opsgenie-monitor-namecoind.sh > /dev/null 2>&1
+*/5 * * * * root bash /root/scripts/watch-namecoind.sh            > /dev/null 2>&1
+

--- a/docker/namecoind/btccom-v0.1-beta/logrotate-namecoind
+++ b/docker/namecoind/btccom-v0.1-beta/logrotate-namecoind
@@ -1,0 +1,6 @@
+/root/.namecoin/debug.log {
+    daily
+    rotate 7
+    missingok
+    copytruncate
+}

--- a/docker/namecoind/btccom-v0.1-beta/opsgenie-monitor-namecoind.sh
+++ b/docker/namecoind/btccom-v0.1-beta/opsgenie-monitor-namecoind.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+#
+# namecoind monitor shell
+#
+# @copyright btc.com
+# @author Zhibiao Pan, Yihao Peng
+# @since 2016-09
+#
+SROOT=$(cd $(dirname "$0"); pwd)
+cd $SROOT
+
+
+# the name of https://app.opsgenie.com/heartbeat
+SERVICE="namecoind.01"
+# api key of opsgenie
+API_KEY="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+# api endpoint
+MURL="https://api.opsgenie.com/v1/json/heartbeat/send"
+# error log
+LOG=/var/log/opsgenie-monitor-namecoind.log
+
+
+NAMECOIND_RPC="namecoin-cli "
+#WANIP=`ip addr | grep 'state UP' -A2 | tail -n1 | awk '{print $2}' | cut -f1  -d'/'`
+#WANIP=`curl https://api.ipify.org`
+#WANIP=`curl http://ipinfo.io/ip`
+
+RPCINFO=`$NAMECOIND_RPC getinfo`
+#NOERROR=`echo "$RPCINFO" |  grep '"errors" : ""' | wc -l`
+HEIGHT=`echo "$RPCINFO" | grep "blocks" | awk '{print $2}' | awk -F"," '{print $1}'`
+CONNS=`echo "$RPCINFO" | grep "connections" | awk '{print $2}' | awk -F"," '{print $1}'`
+DATE=`date "+%Y-%m-%d %H:%M:%S"`
+
+#VALUE="height:$HEIGHT;conn:$CONNS;"
+
+DATA=`cat << EOF
+{"apiKey":"$API_KEY","name":"$SERVICE"}
+EOF`
+
+if [[ $CONNS -ne 0 ]]; then
+  result=`curl -XPOST --max-time 30 -s -S $MURL -d "$DATA" 2>&1`
+  success=`echo "$result" | grep successful`
+
+  if [ "x$success" = "x" ]; then
+    echo "[$DATE] api response is not successful: $result" >>$LOG
+  fi
+
+  echo "$result"
+else
+  echo "[$DATE] namecoind's connections is 0: $RPCINFO" >>$LOG
+  echo "$RPCINFO"
+fi

--- a/docker/namecoind/btccom-v0.1-beta/run
+++ b/docker/namecoind/btccom-v0.1-beta/run
@@ -1,0 +1,12 @@
+#! /bin/bash
+#
+# run shell for namecoind
+#
+# @copyright btc.com
+# @author zhibiao.pan@bitmain.com
+#
+export LC_ALL=C
+SROOT=$(cd $(dirname "$0"); pwd)
+cd $SROOT
+
+namecoind -conf="/root/.namecoin/namecoin.conf" -datadir="/root/.namecoin"

--- a/docker/namecoind/btccom-v0.1-beta/sources-aliyun.com.list
+++ b/docker/namecoind/btccom-v0.1-beta/sources-aliyun.com.list
@@ -1,0 +1,10 @@
+deb http://mirrors.aliyun.com/ubuntu/ xenial main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ xenial-security main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ xenial-updates main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ xenial-proposed main restricted universe multiverse
+deb http://mirrors.aliyun.com/ubuntu/ xenial-backports main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ xenial main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ xenial-security main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ xenial-updates main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ xenial-proposed main restricted universe multiverse
+deb-src http://mirrors.aliyun.com/ubuntu/ xenial-backports main restricted universe multiverse

--- a/docker/namecoind/btccom-v0.1-beta/watch-namecoind.sh
+++ b/docker/namecoind/btccom-v0.1-beta/watch-namecoind.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+#
+# namecoind createauxblock watcher shell
+#
+# this crontab shell is try to fix issue:
+#   https://github.com/namecoin/namecoin-core/issues/50#issuecomment-245571582
+#
+# @copyright btc.com
+# @author Zhibiao Pan
+# @since 2016-09
+#
+SROOT=$(cd $(dirname "$0"); pwd)
+cd $SROOT
+
+NAMECOIND_RPC="namecoin-cli createauxblock N59bssPo1MbK3khwPELTEomyzYbHLb59uY"
+
+SUCCESS=`$NAMECOIND_RPC | grep "previousblockhash" | wc -l`
+
+if [[ $SUCCESS -ne 1 ]]; then
+  IS_DOWNLOADING=`$NAMECOIND_RPC 2>&1 | grep "is downloading blocks" | wc -l` 
+  if [[ $IS_DOWNLOADING -eq 1 ]]; then
+    echo "namecoind is downloading blocks, exit"
+    exit
+  fi
+
+  # stop namecoind, supervisor will start it again
+  echo "got error, restart namecoind..."
+  $NAMECOIND_RPC stop
+fi
+

--- a/src/BlockMaker.cc
+++ b/src/BlockMaker.cc
@@ -407,13 +407,13 @@ void BlockMaker::_submitNamecoinBlockThread(const string &auxBlockHash,
                                             const string &rpcAddress,
                                             const string &rpcUserpass) {
   //
-  // request : getauxblock [<hash> <auxpow>]
+  // request : submitauxblock <hash> <auxpow>
   //
   {
-    const string request = Strings::Format("{\"id\":1,\"method\":\"getauxblock\",\"params\":[\"%s\",\"%s\"]}",
+    const string request = Strings::Format("{\"id\":1,\"method\":\"submitauxblock\",\"params\":[\"%s\",\"%s\"]}",
                                            auxBlockHash.c_str(),
                                            auxPow.c_str());
-    DLOG(INFO) << "getauxblock request: " << request;
+    DLOG(INFO) << "submitauxblock request: " << request;
     // try N times
     for (size_t i = 0; i < 3; i++) {
       string response;

--- a/src/GbtMaker.cc
+++ b/src/GbtMaker.cc
@@ -294,8 +294,9 @@ NMCAuxBlockMaker::NMCAuxBlockMaker(const string &zmqNamecoindAddr,
                                    const string &rpcUserpass,
                                    const string &kafkaBrokers,
                                    uint32_t kRpcCallInterval,
-                                   string fileLastRpcCallTime,
-                                   bool isCheckZmq) :
+                                   const string &fileLastRpcCallTime,
+                                   bool isCheckZmq,
+                                   const string &coinbaseAddress) :
 running_(true), zmqContext_(1/*i/o threads*/),
 zmqNamecoindAddr_(zmqNamecoindAddr),
 rpcAddr_(rpcAddr), rpcUserpass_(rpcUserpass),
@@ -303,7 +304,7 @@ lastCallTime_(0), kRpcCallInterval_(kRpcCallInterval),
 fileLastRpcCallTime_(fileLastRpcCallTime),
 kafkaBrokers_(kafkaBrokers),
 kafkaProducer_(kafkaBrokers_.c_str(), KAFKA_TOPIC_NMC_AUXBLOCK, 0/* partition */),
-isCheckZmq_(isCheckZmq)
+isCheckZmq_(isCheckZmq), coinbaseAddress_(coinbaseAddress)
 {
 }
 
@@ -341,13 +342,15 @@ bool NMCAuxBlockMaker::checkNamecoindZMQ() {
   return false;
 }
 
-bool NMCAuxBlockMaker::callRpcGetAuxBlock(string &resp) {
+bool NMCAuxBlockMaker::callRpcCreateAuxBlock(string &resp) {
   //
   // curl -v  --user "username:password"
-  // -d '{"jsonrpc": "1.0", "id":"curltest", "method": "getauxblock","params": []}'
+  // -d '{"jsonrpc": "1.0", "id":"curltest", "method": "createauxblock","params": []}'
   // -H 'content-type: text/plain;' "http://127.0.0.1:8336"
   //
-  string request = "{\"jsonrpc\":\"1.0\",\"id\":\"1\",\"method\":\"getauxblock\",\"params\":[]}";
+  string request = "{\"jsonrpc\":\"1.0\",\"id\":\"1\",\"method\":\"createauxblock\",\"params\":[\"";
+  request += coinbaseAddress_;
+  request += "\"]}";
   bool res = bitcoindRpcCall(rpcAddr_.c_str(), rpcUserpass_.c_str(),
                              request.c_str(), resp);
   if (!res) {
@@ -359,15 +362,15 @@ bool NMCAuxBlockMaker::callRpcGetAuxBlock(string &resp) {
 
 string NMCAuxBlockMaker::makeAuxBlockMsg() {
   string aux;
-  if (!callRpcGetAuxBlock(aux)) {
+  if (!callRpcCreateAuxBlock(aux)) {
     return "";
   }
-  DLOG(INFO) << "getauxblock json: " << aux;
+  DLOG(INFO) << "createauxblock json: " << aux;
 
   JsonNode r;
   if (!JsonNode::parse(aux.c_str(),
                        aux.c_str() + aux.length(), r)) {
-    LOG(ERROR) << "decode getauxblock json failure: " << aux;
+    LOG(ERROR) << "decode createauxblock json failure: " << aux;
     return "";
   }
 
@@ -408,7 +411,7 @@ string NMCAuxBlockMaker::makeAuxBlockMsg() {
                                r["result"]["bits"].str().c_str(),
                                rpcAddr_.c_str(), rpcUserpass_.c_str());
 
-  LOG(INFO) << "getauxblock, height: " << r["result"]["height"].int32()
+  LOG(INFO) << "createauxblock, height: " << r["result"]["height"].int32()
   << ", hash: " << r["result"]["hash"].str()
   << ", previousblockhash: " << r["result"]["previousblockhash"].str();
 
@@ -425,7 +428,7 @@ void NMCAuxBlockMaker::submitAuxblockMsg(bool checkTime) {
 
   const string auxMsg = makeAuxBlockMsg();
   if (auxMsg.length() == 0) {
-    LOG(ERROR) << "getauxblock failure";
+    LOG(ERROR) << "createauxblock failure";
     return;
   }
   lastCallTime_ = (uint32_t)time(nullptr);
@@ -530,6 +533,24 @@ bool NMCAuxBlockMaker::init() {
     }
   }
 
+  // check aux mining rpc commands: createauxblock & submitauxblock
+  {
+    string response;
+    string request = "{\"jsonrpc\":\"1.0\",\"id\":\"1\",\"method\":\"help\",\"params\":[]}";
+    bool res = bitcoindRpcCall(rpcAddr_.c_str(), rpcUserpass_.c_str(),
+                               request.c_str(), response);
+    if (!res) {
+      LOG(ERROR) << "namecoind rpc call failure";
+      return false;
+    }
+
+    if (response.find("createauxblock") == std::string::npos ||
+        response.find("submitauxblock") == std::string::npos) {
+      LOG(ERROR) << "namecoind doesn't support rpc commands: createauxblock and submitauxblock";
+      return false;
+    }
+  }
+
   if (isCheckZmq_ && !checkNamecoindZMQ())
     return false;
   
@@ -550,7 +571,7 @@ void NMCAuxBlockMaker::run() {
   //
   thread threadListenNamecoind = thread(&NMCAuxBlockMaker::threadListenNamecoind, this);
 
-  // getauxblock interval
+  // createauxblock interval
   while (running_) {
     sleep(1);
     submitAuxblockMsg(true);

--- a/src/GbtMaker.h
+++ b/src/GbtMaker.h
@@ -72,7 +72,7 @@ public:
 
 //////////////////////////////// NMCAuxBlockMaker //////////////////////////////
 //
-// rpc call: ./namecoin-cli getauxblock
+// rpc call: ./namecoin-cli createauxblock N59bssPo1MbK3khwPELTEomyzYbHLb59uY
 //
 class NMCAuxBlockMaker {
   atomic<bool> running_;
@@ -90,9 +90,10 @@ class NMCAuxBlockMaker {
   string kafkaBrokers_;
   KafkaProducer kafkaProducer_;
   bool isCheckZmq_;
+  string coinbaseAddress_;  // nmc coinbase payout address
 
   bool checkNamecoindZMQ();
-  bool callRpcGetAuxBlock(string &resp);
+  bool callRpcCreateAuxBlock(string &resp);
   string makeAuxBlockMsg();
 
   void submitAuxblockMsg(bool checkTime);
@@ -104,7 +105,8 @@ public:
   NMCAuxBlockMaker(const string &zmqNamecoindAddr,
                    const string &rpcAddr, const string &rpcUserpass,
                    const string &kafkaBrokers, uint32_t kRpcCallInterval,
-                   string fileLastRpcCallTime, bool isCheckZmq);
+                   const string &fileLastRpcCallTime, bool isCheckZmq,
+                   const string &coinbaseAddress);
   ~NMCAuxBlockMaker();
 
   bool init();

--- a/src/nmcauxmaker/NMCAuxBlockMakerMain.cc
+++ b/src/nmcauxmaker/NMCAuxBlockMakerMain.cc
@@ -118,13 +118,15 @@ int main(int argc, char **argv) {
   cfg.lookupValue("nmcauxmaker.rpcinterval", rpcCallInterval);
   string fileLastRpcCallTime;
   cfg.lookupValue("nmcauxmaker.file_last_rpc_call_time", fileLastRpcCallTime);
+  string coinbaseAddress;
+  cfg.lookupValue("nmcauxmaker.payout_address", coinbaseAddress);
 
   gNMCAuxBlockMaker = new NMCAuxBlockMaker(cfg.lookup("namecoind.zmq_addr"),
                                            cfg.lookup("namecoind.rpc_addr"),
                                            cfg.lookup("namecoind.rpc_userpwd"),
                                            cfg.lookup("kafka.brokers"),
                                            rpcCallInterval, fileLastRpcCallTime,
-                                           isCheckZmq);
+                                           isCheckZmq, coinbaseAddress);
 
   try {
     if (!gNMCAuxBlockMaker->init()) {

--- a/src/nmcauxmaker/nmcauxmaker.cfg
+++ b/src/nmcauxmaker/nmcauxmaker.cfg
@@ -13,6 +13,11 @@ nmcauxmaker = {
 
   // check zmq when startup
   is_check_zmq = true;
+
+  //
+  // nmc coinbase payout address
+  //
+  payout_address = "N59bssPo1MbK3khwPELTEomyzYbHLb59uY";
 };
 
 namecoind = {


### PR DESCRIPTION
Use new namecoin-core rpc command instead of "getauxblock".

* namecoind could build without wallet(BDB) and will be more stable
* new coins can go to the specified payout address instead of one block one random address, easier to manage your namecoins.

Related PR: [add rpc commands: “createauxblock” and “submitauxblock”](https://github.com/namecoin/namecoin-core/pull/163)
