### PR TITLE
Rsk partial merkle submit

### DIFF
--- a/src/BitcoinUtils.cc
+++ b/src/BitcoinUtils.cc
@@ -28,6 +28,11 @@ std::string EncodeHexBlock(const CBlock &block) {
   ssBlock << block;
   return HexStr(ssBlock.begin(), ssBlock.end());
 }
+std::string EncodeHexBlockHeader(const CBlockHeader &blkHeader) {
+  CDataStream ssBlkHeader(SER_NETWORK, PROTOCOL_VERSION);
+  ssBlkHeader << blkHeader;
+  return HexStr(ssBlkHeader.begin(), ssBlkHeader.end());
+}
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {

--- a/src/BitcoinUtils.h
+++ b/src/BitcoinUtils.h
@@ -39,6 +39,7 @@
 #endif
 
 std::string EncodeHexBlock(const CBlock &block);
+std::string EncodeHexBlockHeader(const CBlockHeader &blkHeader);
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams);
 

--- a/src/BlockMaker.cc
+++ b/src/BlockMaker.cc
@@ -924,14 +924,13 @@ void BlockMaker::consumeRskSolvedShare(rd_kafka_message_t *rkmessage) {
 
   string blockHashHex = blkHeader.GetHash().ToString();
   string blockHeaderHex = EncodeHexBlockHeader(blkHeader);
-  string coinbaseHex;
-  string merkleHashesHex;
-  string totalTxCountHex;
 
   // coinbase bin -> hex
+  string coinbaseHex;  
   Bin2Hex(coinbaseTxBin, coinbaseHex);
 
   // build coinbase's merkle tree branch
+  string merkleHashesHex;
   string hashHex;
   vector<uint256> cbMerkleBranch = ComputeMerkleBranch(vtxhashes, 0);
 
@@ -946,7 +945,7 @@ void BlockMaker::consumeRskSolvedShare(rd_kafka_message_t *rkmessage) {
   // block tx count
   std::stringstream sstream;
   sstream << std::hex << vtxhashes.size();
-  totalTxCountHex = sstream.str();
+  string totalTxCountHex(sstream.str());
 
   submitRskBlockPartialMerkleNonBlocking(shareData.rpcAddress_, shareData.rpcUserPwd_, blockHashHex, blockHeaderHex, 
                                         coinbaseHex, merkleHashesHex, totalTxCountHex);  // using thread

--- a/src/BlockMaker.h
+++ b/src/BlockMaker.h
@@ -117,13 +117,20 @@ class BlockMaker {
                                   const string &rpcAddress,
                                   const string &rpcUserpass);
 
-  void submitRskBlockNonBlocking(const string &rpcAddress,
-                                const string &rpcUserPwd,
-                                const string &blockHex);
-
-  void _submitRskBlockThread(const string &rpcAddress,
-                            const string &rpcUserPwd,
-                            const string &blockHex);
+  void submitRskBlockPartialMerkleNonBlocking(const string &rpcAddress,
+                                              const string &rpcUserPwd,
+                                              const string &blockHashHex, 
+                                              const string &blockHeaderHex, 
+                                              const string &coinbaseHex, 
+                                              const string &merkleHashesHex, 
+                                              const string &totalTxCount);
+  void _submitRskBlockPartialMerkleThread(const string &rpcAddress,
+                                          const string &rpcUserPwd,
+                                          const string &blockHashHex, 
+                                          const string &blockHeaderHex, 
+                                          const string &coinbaseHex, 
+                                          const string &merkleHashesHex, 
+                                          const string &totalTxCount);
   bool submitToRskNode();
 
 public:

--- a/src/gwmaker/gwmaker.cfg
+++ b/src/gwmaker/gwmaker.cfg
@@ -1,23 +1,23 @@
-//
-// gw maker cfg
-//
-// @since 2017-03
-// @copyright RSK Labs Ltd.
-//
+#
+# gw maker cfg
+#
+# @since 2017-03
+# @copyright RSK Labs Ltd.
+#
 
 gwmaker = {
-  // poll period interval seconds
+  # poll period interval seconds
   poll_period = 5;
 
-  // check zmq when startup
+  # check zmq when startup
   is_check_zmq = true;
 };
 
 rskd = {
-  // rpc settings
-  // address format http://127.0.0.1:4444
+  # rpc settings
+  # address format http://127.0.0.1:4444
   rpc_addr    = "http://127.0.0.1:4444";
-  rpc_userpwd = "user:pass";  // username:password
+  rpc_userpwd = "user:pass";  # username:password
 };
 
 kafka = {


### PR DESCRIPTION
This pull request makes the necessary changes to BlockMaker's consumeRskSolvedShare method to make use of the [submitBitcoinBlockPartialMerkle](https://github.com/rsksmart/rskj/wiki/JSON-RPC-API#mnr_submitbitcoinblockpartialmerkle) rpc method provided by RSK node. 

Since the coinbase's partial merkle tree only has log2(n) hashes, where n is the amount of transactions in the block, this method requires much less information than sending a full bitcoin block, thus reducing the bandwith used for submission.