### PR TITLE
blkmaker ETH: record real block hash to database.

### DIFF
--- a/docker/eth-parity/beta-submit_work_detail/README.md
+++ b/docker/eth-parity/beta-submit_work_detail/README.md
@@ -1,0 +1,154 @@
+Docker for Parity Ethereum Node
+============================
+
+* OS: `Ubuntu 16.04 LTS`
+* Docker image: build by yourself
+* Parity version: 2.0.1-beta with eth_submitWorkDetail
+
+## Install Docker CE
+
+```
+# Use official mirrors
+curl -fsSL https://get.docker.com | bash -s docker
+
+# Or use Aliyun mirrors
+curl -fsSL https://get.docker.com | bash -s docker --mirror Aliyun
+```
+
+## Change Image Mirrors and Data Root (optional)
+
+```
+mkdir -p /work/docker
+vim /etc/docker/daemon.json
+```
+
+```
+{
+    "registry-mirrors": ["https://<REPLACED-TO-YOUR-MIRROR-ID>.mirror.aliyuncs.com"],
+    "data-root": "/work/docker"
+}
+```
+
+```
+service docker restart
+```
+
+## Build Docker Image
+
+```
+git clone -b docker https://github.com/btccom/parity-ethereum.git
+cd parity-ethereum
+docker build -t parity:2.0.1-submit_work_detail -f docker/ubuntu/Dockerfile --tag btccom/parity-ethereum:submit_work_detail .
+```
+
+## Create Config Files
+
+### Ethereum
+
+```
+mkdir -p /work/ethereum/eth-parity
+vim /work/ethereum/eth-parity/config.toml
+```
+
+```
+# Parity Config Generator
+# https://paritytech.github.io/parity-config-generator/
+#
+# This config should be placed in following path:
+#   ~/.local/share/io.parity.ethereum/config.toml
+
+[parity]
+# Ethereum Main Network
+chain = "foundation"
+# Parity continously syncs the chain
+mode = "last"
+
+[rpc]
+#  JSON-RPC will be listening for connections on IP 0.0.0.0.
+interface = "0.0.0.0"
+# Allows Cross-Origin Requests from domain '*'.
+cors = ["*"]
+
+[mining]
+# Account address to receive reward when block is mined.
+author = "<REPLACED-TO-YOUR-ADDRESS>"
+# Blocks that you mine will have this text in extra data field.
+extra_data = "/Project BTCPool/"
+
+[network]
+# Parity will sync by downloading stable state first. Node will be operational in couple minutes.
+warp = true
+
+[misc]
+logging = "own_tx,sync=debug"
+log_file = "/root/.local/share/io.parity.ethereum/parity.log"
+```
+
+### Ethereum Classic
+
+```
+mkdir -p /work/ethereum/etc-parity
+vim /work/ethereum/etc-parity/config.toml
+```
+
+```
+# Parity Config Generator
+# https://paritytech.github.io/parity-config-generator/
+#
+# This config should be placed in following path:
+#   ~/.local/share/io.parity.ethereum/config.toml
+
+[parity]
+# Ethereum Classic Main Network
+chain = "classic"
+# Parity continously syncs the chain
+mode = "last"
+
+[rpc]
+#  JSON-RPC will be listening for connections on IP 0.0.0.0.
+interface = "0.0.0.0"
+# Allows Cross-Origin Requests from domain '*'.
+cors = ["*"]
+
+[mining]
+# Account address to receive reward when block is mined.
+author = "<REPLACED-TO-YOUR-ADDRESS>"
+# Blocks that you mine will have this text in extra data field.
+extra_data = "/Project BTCPool/"
+
+[network]
+# Parity will sync by downloading stable state first. Node will be operational in couple minutes.
+warp = true
+
+[misc]
+logging = "own_tx=info,sync=info,chain=info,network=info,miner=info"
+log_file = "/root/.local/share/io.parity.ethereum/parity.log"
+```
+
+## Start Docker Container
+
+### Ethereum
+
+```
+# start docker
+docker run -it -v /work/ethereum/eth-parity/:/root/.local/share/io.parity.ethereum/ -p 8545:8545 -p 30303:30303 --name eth-parity --restart always -d parity:2.0.1-submit_work_detail
+
+# see the log
+tail -f /work/ethereum/eth-parity/parity.log
+
+# login
+docker exec -it eth-parity /bin/bash
+```
+
+### Ethereum Classic
+
+```
+# start docker
+docker run -it -v /work/ethereum/etc-parity/:/root/.local/share/io.parity.ethereum/ -p 8555:8545 -p 30403:30303 --name etc-parity --restart always -d parity:2.0.1-submit_work_detail
+
+# see the log
+tail -f /work/ethereum/etc-parity/parity.log
+
+# login
+docker exec -it eth-parity /bin/bash
+```

--- a/install/bpool_local_db_ETH.sql
+++ b/install/bpool_local_db_ETH.sql
@@ -24,7 +24,8 @@ CREATE TABLE `found_blocks` (
   `network_diff` bigint(20) unsigned NOT NULL,
   `created_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `hash` (`hash`),
+  KEY `hash` (`hash`),
+  KEY `hash_no_nonce` (`hash_no_nonce`),
   KEY `height` (`height`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/install/db.change.ETH.sql
+++ b/install/db.change.ETH.sql
@@ -4,5 +4,8 @@
 -- then add a new field named `found_blocks.hash`.
 --
 ALTER TABLE `found_blocks`
+DROP INDEX `hash`,
 CHANGE `hash` `hash_no_nonce` char(66) NOT NULL,
-ADD `hash` char(66) DEFAULT '' NOT NULL AFTER `ref_uncles`;
+ADD `hash` char(66) DEFAULT '' NOT NULL AFTER `ref_uncles`,
+ADD INDEX `hash`(`hash`),
+ADD INDEX `hash_no_nonce`(`hash_no_nonce`);

--- a/src/eth/BlockMakerEth.cc
+++ b/src/eth/BlockMakerEth.cc
@@ -32,6 +32,16 @@
 BlockMakerEth::BlockMakerEth(const BlockMakerDefinition& def, const char *kafkaBrokers, const MysqlConnectInfo &poolDB) 
   : BlockMaker(def, kafkaBrokers, poolDB)
 {
+  useSubmitBlockDetail_ = checkRpcSubmitBlockDetail();
+  if (useSubmitBlockDetail_) {
+    LOG(INFO) << "use RPC eth_submitBlockDetail";
+  }
+  else if (checkRpcSubmitBlock()) {
+    LOG(INFO) << "use RPC eth_submitBlock, it has limited functionality and the block hash will not be set.";
+  }
+  else {
+    LOG(FATAL) << "Ethereum nodes doesn't support both eth_submitBlockDetail and eth_submitBlock, cannot submit block!";
+  }
 }
 
 void BlockMakerEth::processSolvedShare(rd_kafka_message_t *rkmessage)
@@ -64,56 +74,245 @@ void BlockMakerEth::processSolvedShare(rd_kafka_message_t *rkmessage)
   worker.workerHashId_ = r["workerId"].int64();
   worker.fullName_ = r["workerFullName"].str();
 
+  submitBlockNonBlocking(r["nonce"].str(), r["header"].str(), r["mix"].str(), def_.nodes,
+                         r["height"].uint32(), r["chain"].str(), r["networkDiff"].uint64(),
+                         worker);
+}
+
+bool BlockMakerEth::submitBlock(const string &nonce, const string &header, const string &mix,
+                                const string &rpcUrl, const string &rpcUserPass) {
   string request = Strings::Format("{\"jsonrpc\": \"2.0\", \"method\": \"eth_submitWork\", \"params\": [\"%s\",\"%s\",\"%s\"], \"id\": 5}\n",
-                                   HexAddPrefix(r["nonce"].str()).c_str(),
-                                   HexAddPrefix(r["header"].str()).c_str(),
-                                   HexAddPrefix(r["mix"].str()).c_str());
+                                   HexAddPrefix(nonce).c_str(),
+                                   HexAddPrefix(header).c_str(),
+                                   HexAddPrefix(mix).c_str());
 
-  submitBlockNonBlocking(request);
-  saveBlockToDBNonBlocking(r["header"].str().c_str(), r["height"].uint32(),
-                           r["chain"].str().c_str(), r["networkDiff"].uint64(), worker);
-}
-
-void BlockMakerEth::submitBlockNonBlocking(const string &blockJson) {
-  for (const auto &itr : nodeRpcUri_) {
-    // use thread to submit
-    boost::thread t(boost::bind(&BlockMakerEth::_submitBlockThread, this,
-                                itr.first, itr.second, blockJson));
-  }
-}
-
-void BlockMakerEth::_submitBlockThread(const string &rpcAddress, const string &rpcUserpass,
-                                       const string &blockJson)
-{
   string response;
-  LOG(INFO) << "submit ETH block: " << blockJson;
-  blockchainNodeRpcCall(rpcAddress.c_str(), rpcUserpass.c_str(), blockJson.c_str(), response);
-  LOG(INFO) << "submission result: " << response;
+  bool ok = blockchainNodeRpcCall(rpcUrl.c_str(), rpcUserPass.c_str(), request.c_str(), response);
+  DLOG(INFO) << "eth_submitWork request: " << request;
+  DLOG(INFO) << "eth_submitWork response: " << response;
+  if (!ok) {
+    LOG(WARNING) << "Call RPC eth_submitWork failed, node url: " << rpcUrl;
+    return false;
+  }
+
+  JsonNode r;
+  if (!JsonNode::parse(response.c_str(), response.c_str() + response.size(), r)) {
+    LOG(WARNING) << "decode response failure, node url: " << rpcUrl << ", response: " << response;
+    return false;
+  }
+
+  if (r.type() != Utilities::JS::type::Obj || r["result"].type() != Utilities::JS::type::Bool) {
+    LOG(WARNING) << "node doesn't support eth_submitWork, node url: " << rpcUrl << ", response: " << response;
+    return false;
+  }
+
+  return r["result"].boolean();
 }
 
-void BlockMakerEth::saveBlockToDBNonBlocking(const string &header, const uint32_t height, const string &chain,
-                                             const uint64_t networkDiff, const StratumWorker &worker) {
-  boost::thread t(boost::bind(&BlockMakerEth::_saveBlockToDBThread, this,
-                              header, height, chain, networkDiff, worker));
+/**
+  * RPC eth_submitWorkDetail:
+  *     A new RPC to submit POW work to Ethereum node. It has the same functionality as `eth_submitWork`
+  *     but returns more details about the submitted block.
+  *     It defined by the BTCPool project and implemented in the Parity Ethereum node as a patch.
+  * 
+  * Params (same as `eth_submitWork`):
+  *     [
+  *         (string) nonce,
+  *         (string) pow_hash,
+  *         (string) mix_hash
+  *     ]
+  * 
+  * Result:
+  *     [
+  *         (bool)           success,
+  *         (string or null) error_msg,
+  *         (string or null) block_hash,
+  *         ... // more fields may added in the future
+  *     ]
+  */
+bool BlockMakerEth::submitBlockDetail(const string &nonce, const string &header, const string &mix,
+                                      const string &rpcUrl, const string &rpcUserPass,
+                                      string &errMsg, string &blockHash) {
+  
+  string request = Strings::Format("{\"jsonrpc\": \"2.0\", \"method\": \"eth_submitWorkDetail\", \"params\": [\"%s\",\"%s\",\"%s\"], \"id\": 5}\n",
+                                   HexAddPrefix(nonce).c_str(),
+                                   HexAddPrefix(header).c_str(),
+                                   HexAddPrefix(mix).c_str());
+
+  string response;
+  bool ok = blockchainNodeRpcCall(rpcUrl.c_str(), rpcUserPass.c_str(), request.c_str(), response);
+  DLOG(INFO) << "eth_submitWorkDetail request: " << request;
+  DLOG(INFO) << "eth_submitWorkDetail response: " << response;
+  if (!ok) {
+    LOG(WARNING) << "Call RPC eth_submitWorkDetail failed, node url: " << rpcUrl;
+    return false;
+  }
+
+  JsonNode r;
+  if (!JsonNode::parse(response.c_str(), response.c_str() + response.size(), r)) {
+    LOG(WARNING) << "decode response failure, node url: " << rpcUrl << ", response: " << response;
+    return false;
+  }
+
+  if (r.type() != Utilities::JS::type::Obj || r["result"].type() != Utilities::JS::type::Array) {
+    LOG(WARNING) << "node doesn't support eth_submitWorkDetail, node url: " << rpcUrl << ", response: " << response;
+    return false;
+  }
+
+  auto result = r["result"].children();
+
+  bool success = false;
+  if (result->size() >= 1 && result->at(0).type() == Utilities::JS::type::Bool) {
+    success = result->at(0).boolean();
+  }
+
+  if (result->size() >= 2 && result->at(1).type() == Utilities::JS::type::Str) {
+    errMsg = result->at(1).str();
+  }
+
+  if (result->size() >= 3 && result->at(2).type() == Utilities::JS::type::Str) {
+    blockHash = result->at(2).str();
+  }
+
+  return success;
 }
 
-void BlockMakerEth::_saveBlockToDBThread(const string &header, const uint32_t height, const string &chain,
-                                         const uint64_t networkDiff, const StratumWorker &worker) {
+bool BlockMakerEth::checkRpcSubmitBlock() {
+  string request = Strings::Format("{\"jsonrpc\": \"2.0\", \"method\": \"eth_submitWork\", \"params\": [\"%s\",\"%s\",\"%s\"], \"id\": 5}\n",
+                                   "0x0000000000000000",
+                                   "0x0000000000000000000000000000000000000000000000000000000000000000",
+                                   "0x0000000000000000000000000000000000000000000000000000000000000000");
+
+  for (const auto &itr : nodeRpcUri_) {
+    string response;
+    bool ok = blockchainNodeRpcCall(itr.first.c_str(), itr.second.c_str(), request.c_str(), response);
+    if (!ok) {
+      LOG(WARNING) << "Call RPC eth_submitWork failed, node url: " << itr.first;
+      return false;
+    }
+
+    JsonNode r;
+    if (!JsonNode::parse(response.c_str(), response.c_str() + response.size(), r)) {
+      LOG(WARNING) << "decode response failure, node url: " << itr.first << ", response: " << response;
+      return false;
+    }
+
+    if (r.type() != Utilities::JS::type::Obj || r["result"].type() != Utilities::JS::type::Bool) {
+      LOG(WARNING) << "node doesn't support eth_submitWork, node url: " << itr.first << ", response: " << response;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool BlockMakerEth::checkRpcSubmitBlockDetail() {
+  string request = Strings::Format("{\"jsonrpc\": \"2.0\", \"method\": \"eth_submitWorkDetail\", \"params\": [\"%s\",\"%s\",\"%s\"], \"id\": 5}\n",
+                                   "0x0000000000000000",
+                                   "0x0000000000000000000000000000000000000000000000000000000000000000",
+                                   "0x0000000000000000000000000000000000000000000000000000000000000000");
+
+  for (const auto &itr : nodeRpcUri_) {
+    string response;
+    bool ok = blockchainNodeRpcCall(itr.first.c_str(), itr.second.c_str(), request.c_str(), response);
+    if (!ok) {
+      LOG(WARNING) << "Call RPC eth_submitWorkDetail failed, node url: " << itr.first;
+      return false;
+    }
+
+    JsonNode r;
+    if (!JsonNode::parse(response.c_str(), response.c_str() + response.size(), r)) {
+      LOG(WARNING) << "decode response failure, node url: " << itr.first << ", response: " << response;
+      return false;
+    }
+
+    if (r.type() != Utilities::JS::type::Obj ||
+      r["result"].type() != Utilities::JS::type::Array ||
+      r["result"].children()->size() < 3 ||
+      r["result"].children()->at(0).type() != Utilities::JS::type::Bool)
+    {
+      LOG(WARNING) << "node doesn't support eth_submitWorkDetail, node url: " << itr.first << ", response: " << response;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void BlockMakerEth::submitBlockNonBlocking(const string &nonce, const string &header, const string &mix, const vector<NodeDefinition> &nodes,
+                                           const uint32_t height, const string &chain, const uint64_t networkDiff, const StratumWorker &worker) {
+  boost::thread t(boost::bind(&BlockMakerEth::_submitBlockThread, this,
+                              nonce, header, mix, nodes,
+                              height, chain, networkDiff, worker));
+}
+
+void BlockMakerEth::_submitBlockThread(const string &nonce, const string &header, const string &mix, const vector<NodeDefinition> &nodes,
+                                       const uint32_t height, const string &chain, const uint64_t networkDiff, const StratumWorker &worker) {
+  string blockHash;
+
+  int retryTime = 5;
+  while (retryTime > 0) {
+    if (useSubmitBlockDetail_) {
+      // try eth_submitWorkDetail
+      for (size_t i=0; i<nodes.size(); i++) {
+        string errMsg;
+        auto node = nodes[i];
+        bool success = submitBlockDetail(nonce, header, mix, node.rpcAddr_, node.rpcUserPwd_,
+                                         errMsg, blockHash);
+        if (success) {
+          LOG(INFO) << "eth_submitWorkDetail success, chain: " << chain << ", height: " << height << ", hash: " << blockHash
+                    << ", networkDiff: " << networkDiff << ", worker: " << worker.fullName_;
+          break;
+        }
+
+        LOG(WARNING) << "eth_submitWorkDetail failed, chain: " << chain << ", height: " << height << ", hash_no_nonce: " << header
+                     << ", err_msg: " << errMsg;
+      }
+    }
+
+    {
+      // try eth_submitWork
+      for (size_t i=0; i<nodes.size(); i++) {
+        auto node = nodes[i];
+        bool success = submitBlock(nonce, header, mix, node.rpcAddr_, node.rpcUserPwd_);
+        if (success) {
+          LOG(INFO) << "eth_submitWork success, chain: " << chain << ", height: " << height << ", hash_no_nonce: " << header
+                    << ", networkDiff: " << networkDiff << ", worker: " << worker.fullName_;
+          break;
+        }
+
+        LOG(WARNING) << "eth_submitWork failed, chain: " << chain << ", height: " << height << ", hash_no_nonce: " << header;
+      }
+    }
+
+    sleep(6 - retryTime); // first sleep 1s, second sleep 2s, ...
+    retryTime--;
+  }
+
+  // Still writing to the database even if submitting failed
+  saveBlockToDB(header, blockHash, height, chain, networkDiff, worker);
+}
+
+void BlockMakerEth::saveBlockToDB(const string &header, const string &blockHash, const uint32_t height,
+                                  const string &chain, const uint64_t networkDiff, const StratumWorker &worker) {
   const string nowStr = date("%F %T");
   string sql;
   sql = Strings::Format("INSERT INTO `found_blocks` "
                         " (`puid`, `worker_id`"
                         ", `worker_full_name`, `chain`"
-                        ", `height`, `hash_no_nonce`, `rewards`"
+                        ", `height`, `hash`, `hash_no_nonce`"
+                        ", `rewards`"
                         ", `network_diff`, `created_at`)"
                         " VALUES (%ld, %" PRId64
                         ", '%s', '%s'"
-                        ", %lu, '%s', %" PRId64
+                        ", %lu, '%s', '%s'"
+                        ", %" PRId64
                         ", %" PRIu64 ", '%s'); ",
                         worker.userId_, worker.workerHashId_,
                         // filter again, just in case
                         filterWorkerName(worker.fullName_).c_str(), chain.c_str(),
-                        height, header.c_str(), EthConsensus::getStaticBlockReward(height, chain),
+                        height, blockHash.c_str(), header.c_str(),
+                        EthConsensus::getStaticBlockReward(height, chain),
                         networkDiff, nowStr.c_str());
 
   // try connect to DB

--- a/src/eth/BlockMakerEth.cc
+++ b/src/eth/BlockMakerEth.cc
@@ -37,7 +37,7 @@ BlockMakerEth::BlockMakerEth(const BlockMakerDefinition& def, const char *kafkaB
     LOG(INFO) << "use RPC eth_submitBlockDetail";
   }
   else if (checkRpcSubmitBlock()) {
-    LOG(INFO) << "use RPC eth_submitBlock, it has limited functionality and the block hash will not be set.";
+    LOG(INFO) << "use RPC eth_submitBlock, it has limited functionality and the block hash will not be recorded.";
   }
   else {
     LOG(FATAL) << "Ethereum nodes doesn't support both eth_submitBlockDetail and eth_submitBlock, cannot submit block!";

--- a/src/eth/BlockMakerEth.h
+++ b/src/eth/BlockMakerEth.h
@@ -35,10 +35,22 @@ public:
   void processSolvedShare(rd_kafka_message_t *rkmessage) override;
 
 private:
-  void submitBlockNonBlocking(const string &blockJson);
-  void _submitBlockThread(const string &rpcAddress, const string &rpcUserpass, const string &blockJson);
-  void saveBlockToDBNonBlocking(const string &header, const uint32_t height, const string &chain, const uint64_t networkDiff, const StratumWorker &worker);
-  void _saveBlockToDBThread(const string &header, const uint32_t height, const string &chain, const uint64_t networkDiff, const StratumWorker &worker);
+  void submitBlockNonBlocking(const string &nonce, const string &header, const string &mix, const vector<NodeDefinition> &nodes,
+                              const uint32_t height, const string &chain, const uint64_t networkDiff, const StratumWorker &worker);
+  void _submitBlockThread(const string &nonce, const string &header, const string &mix, const vector<NodeDefinition> &nodes,
+                          const uint32_t height, const string &chain, const uint64_t networkDiff, const StratumWorker &worker);
+  void saveBlockToDB(const string &header, const string &blockHash, const uint32_t height,
+                     const string &chain, const uint64_t networkDiff, const StratumWorker &worker);
+
+  bool submitBlock(const string &nonce, const string &header, const string &mix,
+                   const string &rpcUrl, const string &rpcUserPass);
+  bool submitBlockDetail(const string &nonce, const string &header, const string &mix,
+                         const string &rpcUrl, const string &rpcUserPass,
+                         string &errMsg, string &blockHash);
+  bool checkRpcSubmitBlock();
+  bool checkRpcSubmitBlockDetail();
+
+  bool useSubmitBlockDetail_;
 };
 
 #endif


### PR DESCRIPTION
Use the RPC `eth_submitWorkDetail` that added to Parity Ethereum node by ourselves. Also compatible with nodes that do not support `eth_submitWorkDetail`.