### PR TITLE
Optimize job maker ZooKeeper lock

### DIFF
--- a/src/JobMaker.h
+++ b/src/JobMaker.h
@@ -109,6 +109,8 @@ public:
   JobMakerConsumerHandler createConsumerHandler(const string &kafkaBrokers, const string &topic, int64_t offset
     , vector<pair<string, string>> consumerOptions, JobMakerMessageProcessor messageProcessor);
 
+  uint64_t generateJobId(uint32_t hash) const;
+
 protected:
   shared_ptr<JobMakerDefinition> def_;
 };

--- a/src/bytom/JobMakerBytom.cc
+++ b/src/bytom/JobMakerBytom.cc
@@ -78,15 +78,9 @@ string JobMakerHandlerBytom::makeStratumJobMsg()
       0 == seed_.size())
     return "";
 
-
-  const string jobIdStr = Strings::Format("%08x%08x", (uint32_t)time(nullptr), djb2(header_.c_str()));
-  assert(jobIdStr.length() == 16);
-  size_t pos;
-  uint64 jobId = stoull(jobIdStr, &pos, 16);
-
   StratumJobBytom job;
   job.nTime_ = time_;
-  job.jobId_ = jobId;
+  job.jobId_ = generateJobId(djb2(header_.c_str()));
   job.seed_ = seed_;
   job.hHash_ = header_;
   return job.serializeToJson();

--- a/src/decred/JobMakerDecred.cc
+++ b/src/decred/JobMakerDecred.cc
@@ -73,7 +73,7 @@ string JobMakerHandlerDecred::makeStratumJobMsg()
 
   auto& work = *works_.get<ByBestBlockDecred>().rbegin();
   auto& data = work.data;
-  auto jobId = static_cast<uint64_t>(time(nullptr)) << 32 | djb2(data.c_str());
+  auto jobId = generateJobId(djb2(data.c_str()));
   auto prevHash = data.substr(OFFSET_AND_SIZE_DECRED(prevBlock));
   auto merkelRootOffset = offsetof(BlockHeaderDecred, merkelRoot);
   auto coinBase1 = data.substr(merkelRootOffset * 2, (offsetof(BlockHeaderDecred, extraData) - merkelRootOffset) * 2);

--- a/src/eth/JobMakerEth.cc
+++ b/src/eth/JobMakerEth.cc
@@ -101,7 +101,7 @@ string JobMakerHandlerEth::makeStratumJobMsg()
   shared_ptr<RskWorkEth> work = workMap_.rbegin()->second;
   StratumJobEth sjob;
 
-  if (!sjob.initFromGw(*work, def()->chain_)) {
+  if (!sjob.initFromGw(*work, def()->chain_, def()->serverId_)) {
     LOG(ERROR) << "init stratum job from work fail";
     return "";
   }

--- a/src/eth/StratumEth.cc
+++ b/src/eth/StratumEth.cc
@@ -38,7 +38,7 @@ StratumJobEth::StratumJobEth()
 
 }
 
-bool StratumJobEth::initFromGw(const RskWorkEth &latestRskBlockJson, EthConsensus::Chain chain)
+bool StratumJobEth::initFromGw(const RskWorkEth &latestRskBlockJson, EthConsensus::Chain chain, uint8_t serverId)
 {
   if (latestRskBlockJson.isInitialized())
   {
@@ -54,16 +54,8 @@ bool StratumJobEth::initFromGw(const RskWorkEth &latestRskBlockJson, EthConsensu
 
     // generate job id
     string header = blockHashForMergedMining_.substr(2, 64);
-    uint32 h = djb2(header.c_str());
-    DLOG(INFO) << "djb2=" << std::hex << h << " for header " << header;
-    // jobId: timestamp + hash of header
-    const string jobIdStr = Strings::Format("%08x%08x",
-                                            (uint32_t)time(nullptr),
-                                            h);
-    DLOG(INFO) << "job id string: " << jobIdStr;
-    assert(jobIdStr.length() == 16);
-    
-    jobId_ = stoull(jobIdStr, nullptr, 16 /* hex */);
+    // jobId: timestamp + hash of header + server id
+    jobId_ = (static_cast<uint64_t>(time(nullptr)) << 32) | (djb2(header.c_str()) & 0xFFFFFF00) | serverId;
   }
   return seedHash_.size() && blockHashForMergedMining_.size();
 }

--- a/src/eth/StratumEth.h
+++ b/src/eth/StratumEth.h
@@ -183,7 +183,7 @@ public:
   StratumJobEth();
   string serializeToJson() const override;
   bool unserializeFromJson(const char *s, size_t len) override;
-  bool initFromGw(const RskWorkEth &latestRskBlockJson, EthConsensus::Chain chain);
+  bool initFromGw(const RskWorkEth &latestRskBlockJson, EthConsensus::Chain chain, uint8_t serverId);
 
   int32_t height_;
   int32_t nVersion_;

--- a/src/sia/JobMakerSia.cc
+++ b/src/sia/JobMakerSia.cc
@@ -88,10 +88,7 @@ string JobMakerHandlerSia::makeStratumJobMsg()
       0 == target_.size())
     return "";
 
-  const string jobIdStr = Strings::Format("%08x%08x", (uint32_t)time(nullptr), djb2(header_.c_str()));
-  assert(jobIdStr.length() == 16);
-  size_t pos;
-  uint64 jobId = stoull(jobIdStr, &pos, 16);
+  uint64 jobId = generateJobId(djb2(header_.c_str()));
 
   return Strings::Format("{\"created_at_ts\":%u"
                          ",\"jobId\":%" PRIu64 ""


### PR DESCRIPTION
There is a ZooKeeper lock in job maker to prevent multiple instances of
the same job maker configuration. This is to ensure the job id
uniqueness. However we can embed the server id in job id to ensure this
while running multiple job maker instances. The ZooKeeper lock now locks
the path with server id at the end so that we won't start the job maker
with the same server id.