### PR TITLE
ETH: do not accept stale shares

### DIFF
--- a/src/eth/ShareLogParserEth.cc
+++ b/src/eth/ShareLogParserEth.cc
@@ -27,5 +27,7 @@
 // Without this, some linking errors will issued.
 // If you add a new derived class of Share, add it at the following.
 template class ShareLogDumperT<ShareEth>;
-template class ShareLogParserT<ShareEth>;
-template class ShareLogParserServerT<ShareEth>;
+template class ShareLogParserT<ShareNoStaleEth>;
+template class ShareLogParserT<ShareWithStaleEth>;
+template class ShareLogParserServerT<ShareNoStaleEth>;
+template class ShareLogParserServerT<ShareWithStaleEth>;

--- a/src/eth/ShareLogParserEth.h
+++ b/src/eth/ShareLogParserEth.h
@@ -30,7 +30,10 @@
 
 ///////////////////////////////  Alias  ///////////////////////////////
 using ShareLogDumperEth = ShareLogDumperT<ShareEth>;
-using ShareLogParserEth = ShareLogParserT<ShareEth>;
-using ShareLogParserServerEth = ShareLogParserServerT<ShareEth>;
+using ShareLogParserNoStaleEth = ShareLogParserT<ShareNoStaleEth>;
+using ShareLogParserWithStaleEth = ShareLogParserT<ShareWithStaleEth>;
+using ShareLogParserServerNoStaleEth = ShareLogParserServerT<ShareNoStaleEth>;
+using ShareLogParserServerWithStaleEth =
+    ShareLogParserServerT<ShareWithStaleEth>;
 
 #endif // SHARELOGPARSER_H_

--- a/src/eth/StatisticsEth.h
+++ b/src/eth/StatisticsEth.h
@@ -51,8 +51,13 @@ struct GlobalShareEth {
     return false;
   }
 };
+
 ////////////////////////////  Alias  ////////////////////////////
 using DuplicateShareCheckerEth =
     DuplicateShareCheckerT<ShareEth, GlobalShareEth>;
+using DuplicateShareCheckerNoStaleEth =
+    DuplicateShareCheckerT<ShareNoStaleEth, GlobalShareEth>;
+using DuplicateShareCheckerWithStaleEth =
+    DuplicateShareCheckerT<ShareWithStaleEth, GlobalShareEth>;
 
 #endif // STATISTICS_ETH_H_

--- a/src/eth/StatsHttpdEth.cc
+++ b/src/eth/StatsHttpdEth.cc
@@ -26,5 +26,5 @@
 ///////////////  template instantiation ///////////////
 // Without this, some linking errors will issued.
 // If you add a new derived class of Share, add it at the following.
-template class WorkerShares<ShareEth>;
-template class StatsServerT<ShareEth>;
+template class WorkerShares<ShareNoStaleEth>;
+template class StatsServerT<ShareWithStaleEth>;

--- a/src/eth/StatsHttpdEth.h
+++ b/src/eth/StatsHttpdEth.h
@@ -28,6 +28,7 @@
 #include "StratumEth.h"
 
 ////////////////////////////  Alias  ////////////////////////////
-using StatsServerEth = StatsServerT<ShareEth>;
+using StatsServerNoStaleEth = StatsServerT<ShareNoStaleEth>;
+using StatsServerWithStaleEth = StatsServerT<ShareWithStaleEth>;
 
 #endif // STATSHTTPD_BYTOM_H_

--- a/src/slparser/slparser.cfg
+++ b/src/slparser/slparser.cfg
@@ -27,6 +27,10 @@ sharelog = {
   # The user can change the height in the configuration file
   # after the fork height is determined.
   constantinople_height = 9999999;
+
+  # Whether to accept stale shares for ETH/ETC. If this is set to true,
+  # stale shares have a reward ratio similar as uncle blocks.
+  accept_stale = false;
 };
 
 # Used to detect duplicate share attacks on ETH mining.

--- a/src/statshttpd/statshttpd.cfg
+++ b/src/statshttpd/statshttpd.cfg
@@ -28,6 +28,10 @@ statshttpd = {
   # write last db flush time to file
   file_last_flush_time = "/work/btcpool/build/run_statshttpd/statshttpd_lastflushtime.txt";
 
+  # Whether to accept stale shares for ETH/ETC. If this is set to true,
+  # stale shares have a reward ratio similar as uncle blocks.
+  accept_stale = false;
+
   # write mining workers' info to mysql database
   use_mysql = true;
   # write mining workers' info to redis


### PR DESCRIPTION
Stale shares might become uncle block, but most of time they will not.
It incurs small loss to the pool side.