### PR TITLE
BTC: move mining.suggest_target handling

### DIFF
--- a/src/bitcoin/StratumMinerBitcoin.cc
+++ b/src/bitcoin/StratumMinerBitcoin.cc
@@ -49,8 +49,6 @@ void StratumMinerBitcoin::handleRequest(
     const JsonNode &jroot) {
   if (method == "mining.submit") {
     handleRequest_Submit(idStr, jparams);
-  } else if (method == "mining.suggest_target") {
-    handleRequest_SuggestTarget(idStr, jparams);
   }
 }
 
@@ -114,20 +112,6 @@ void StratumMinerBitcoin::handleRequest_Submit(
 
   handleRequest_Submit(
       idStr, shortJobId, extraNonce2, nonce, nTime, versionMask);
-}
-
-void StratumMinerBitcoin::handleRequest_SuggestTarget(
-    const string &idStr, const JsonNode &jparams) {
-  auto &session = getSession();
-  if (session.getState() != StratumSession::CONNECTED) {
-    return; // suggest should be call before subscribe
-  }
-
-  if (jparams.children()->size() == 0) {
-    session.responseError(idStr, StratumStatus::ILLEGAL_PARARMS);
-    return;
-  }
-  resetCurDiff(formatDifficulty(TargetToDiff(jparams.children()->at(0).str())));
 }
 
 void StratumMinerBitcoin::handleExMessage_SubmitShare(

--- a/src/bitcoin/StratumMinerBitcoin.h
+++ b/src/bitcoin/StratumMinerBitcoin.h
@@ -46,8 +46,6 @@ public:
 
 private:
   void handleRequest_Submit(const std::string &idStr, const JsonNode &jparams);
-  void handleRequest_SuggestTarget(
-      const std::string &idStr, const JsonNode &jparams);
   void handleExMessage_SubmitShare(
       const std::string &exMessage,
       const bool isWithTime,

--- a/src/bitcoin/StratumSessionBitcoin.cc
+++ b/src/bitcoin/StratumSessionBitcoin.cc
@@ -46,7 +46,8 @@ StratumSessionBitcoin::StratumSessionBitcoin(
   : StratumSessionBase(server, bev, saddr, extraNonce1)
   , shortJobIdIdx_(0)
   , versionMask_(0)
-  , suggestedMinDiff_(0) {
+  , suggestedMinDiff_(0)
+  , suggestedDiff_(0) {
 }
 
 uint16_t
@@ -145,6 +146,8 @@ void StratumSessionBitcoin::handleRequest(
     handleRequest_MiningConfigure(idStr, jparams);
   } else if (method == "agent.get_capabilities") {
     handleRequest_AgentGetCapabilities(idStr, jparams);
+  } else if (method == "mining.suggest_target") {
+    handleRequest_SuggestTarget(idStr, jparams);
   } else {
     dispatcher_->handleRequest(idStr, method, jparams, jroot);
   }
@@ -390,6 +393,23 @@ void StratumSessionBitcoin::handleRequest_Authorize(
   return;
 }
 
+void StratumSessionBitcoin::handleRequest_SuggestTarget(
+    const string &idStr, const JsonNode &jparams) {
+  if (state_ != CONNECTED) {
+    responseError(idStr, StratumStatus::ILLEGAL_METHOD);
+    return; // suggest should be call before subscribe
+  }
+
+  if (jparams.children()->size() == 0) {
+    responseError(idStr, StratumStatus::ILLEGAL_PARARMS);
+    return;
+  }
+
+  suggestedDiff_ =
+      formatDifficulty(TargetToDiff(jparams.children()->at(0).str()));
+  responseTrue(idStr);
+}
+
 void StratumSessionBitcoin::logAuthorizeResult(bool success) {
   if (success) {
     LOG(INFO) << "authorize success, userId: " << worker_.userId_
@@ -461,6 +481,10 @@ unique_ptr<StratumMiner> StratumSessionBitcoin::createMiner(
 
   if (suggestedMinDiff_ != 0) {
     miner->setMinDiff(suggestedMinDiff_);
+  }
+
+  if (suggestedDiff_ != 0) {
+    miner->resetCurDiff(suggestedDiff_);
   }
 
   return miner;

--- a/src/bitcoin/StratumSessionBitcoin.h
+++ b/src/bitcoin/StratumSessionBitcoin.h
@@ -55,6 +55,8 @@ protected:
   // request from BTCAgent
   void handleRequest_AgentGetCapabilities(
       const string &idStr, const JsonNode &jparams);
+  void handleRequest_SuggestTarget(
+      const std::string &idStr, const JsonNode &jparams);
 
   void logAuthorizeResult(bool success) override;
   string getMinerInfoJson(const string &type) override;
@@ -74,6 +76,7 @@ private:
 
   uint32_t versionMask_; // version mask that the miner wants
   uint64_t suggestedMinDiff_; // min difficulty that the miner wants
+  uint64_t suggestedDiff_; // difficulty that the miner wants
 };
 
 #endif // #ifndef STRATUM_SESSION_BITCOIN_H_


### PR DESCRIPTION
Miner is created after mining.authorize but mining.suggest_target is
sent before mining.subscribe. Hence we need to move the handling to
session level.