### PR TITLE
ZMQ reconnection upon receive timeout

### DIFF
--- a/src/bitcoin/GbtMaker.cc
+++ b/src/bitcoin/GbtMaker.cc
@@ -142,7 +142,7 @@ GbtMaker::GbtMaker(
     uint32_t kRpcCallInterval,
     bool isCheckZmq)
   : running_(true)
-  , zmqContext_(1 /*i/o threads*/)
+  , zmqContext_(std::make_unique<zmq::context_t>(1 /*i/o threads*/))
   , zmqBitcoindAddr_(zmqBitcoindAddr)
   , zmqTimeout_(zmqTimeout)
   , bitcoindRpcAddr_(bitcoindRpcAddr)
@@ -184,7 +184,7 @@ bool GbtMaker::init() {
   }
 
   if (isCheckZmq_ &&
-      !CheckZmqPublisher(zmqContext_, zmqBitcoindAddr_, BITCOIND_ZMQ_HASHTX))
+      !CheckZmqPublisher(*zmqContext_, zmqBitcoindAddr_, BITCOIND_ZMQ_HASHTX))
     return false;
 
   return true;
@@ -195,6 +195,7 @@ void GbtMaker::stop() {
     return;
   }
   running_ = false;
+  zmqContext_.reset();
   LOG(INFO) << "stop gbtmaker";
 }
 
@@ -385,7 +386,7 @@ void GbtMaker::submitRawGbtLightMsg(bool checkTime) {
 
 void GbtMaker::threadListenBitcoind() {
   ListenToZmqPublisher(
-      zmqContext_,
+      *zmqContext_,
       zmqBitcoindAddr_,
       BITCOIND_ZMQ_HASHBLOCK,
       running_,
@@ -432,7 +433,7 @@ NMCAuxBlockMaker::NMCAuxBlockMaker(
     bool isCheckZmq,
     const string &coinbaseAddress)
   : running_(true)
-  , zmqContext_(1 /*i/o threads*/)
+  , zmqContext_(std::make_unique<zmq::context_t>(1 /*i/o threads*/))
   , zmqNamecoindAddr_(zmqNamecoindAddr)
   , zmqTimeout_(zmqTimeout)
   , rpcAddr_(rpcAddr)
@@ -580,7 +581,7 @@ void NMCAuxBlockMaker::submitAuxblockMsg(bool checkTime) {
 
 void NMCAuxBlockMaker::threadListenNamecoind() {
   ListenToZmqPublisher(
-      zmqContext_,
+      *zmqContext_,
       zmqNamecoindAddr_,
       NAMECOIND_ZMQ_HASHBLOCK,
       running_,
@@ -636,7 +637,7 @@ bool NMCAuxBlockMaker::init() {
   }
 
   if (isCheckZmq_ &&
-      !CheckZmqPublisher(zmqContext_, zmqNamecoindAddr_, NAMECOIND_ZMQ_HASHTX))
+      !CheckZmqPublisher(*zmqContext_, zmqNamecoindAddr_, NAMECOIND_ZMQ_HASHTX))
     return false;
 
   return true;
@@ -647,6 +648,7 @@ void NMCAuxBlockMaker::stop() {
     return;
   }
   running_ = false;
+  zmqContext_.reset();
   LOG(INFO) << "stop namecoin auxblock maker";
 }
 

--- a/src/bitcoin/GbtMaker.h
+++ b/src/bitcoin/GbtMaker.h
@@ -36,6 +36,7 @@ class GbtMaker {
 
   zmq::context_t zmqContext_;
   string zmqBitcoindAddr_;
+  uint32_t zmqTimeout_;
 
   string bitcoindRpcAddr_;
   string bitcoindRpcUserpass_;
@@ -67,6 +68,7 @@ class GbtMaker {
 public:
   GbtMaker(
       const string &zmqBitcoindAddr,
+      uint32_t zmqTimeout,
       const string &bitcoindRpcAddr,
       const string &bitcoindRpcUserpass,
       const string &kafkaBrokers,
@@ -93,6 +95,7 @@ class NMCAuxBlockMaker {
 
   zmq::context_t zmqContext_;
   string zmqNamecoindAddr_;
+  uint32_t zmqTimeout_;
 
   string rpcAddr_;
   string rpcUserpass_;
@@ -118,6 +121,7 @@ class NMCAuxBlockMaker {
 public:
   NMCAuxBlockMaker(
       const string &zmqNamecoindAddr,
+      uint32_t zmqTimeout,
       const string &rpcAddr,
       const string &rpcUserpass,
       const string &kafkaBrokers,

--- a/src/bitcoin/GbtMaker.h
+++ b/src/bitcoin/GbtMaker.h
@@ -50,8 +50,6 @@ class GbtMaker {
   KafkaProducer kafkaProducer_;
   bool isCheckZmq_;
 
-  bool checkBitcoindZMQ();
-
   bool bitcoindRpcGBT(string &resp);
   string makeRawGbtMsg();
   void submitRawGbtMsg(bool checkTime);
@@ -109,7 +107,6 @@ class NMCAuxBlockMaker {
   string coinbaseAddress_; // nmc coinbase payout address
   bool useCreateAuxBlockInterface_;
 
-  bool checkNamecoindZMQ();
   bool callRpcCreateAuxBlock(string &resp);
   string makeAuxBlockMsg();
 

--- a/src/bitcoin/GbtMaker.h
+++ b/src/bitcoin/GbtMaker.h
@@ -34,7 +34,7 @@ class GbtMaker {
   atomic<bool> running_;
   mutex lock_;
 
-  zmq::context_t zmqContext_;
+  std::unique_ptr<zmq::context_t> zmqContext_;
   string zmqBitcoindAddr_;
   uint32_t zmqTimeout_;
 
@@ -93,7 +93,7 @@ class NMCAuxBlockMaker {
   atomic<bool> running_;
   mutex lock_;
 
-  zmq::context_t zmqContext_;
+  std::unique_ptr<zmq::context_t> zmqContext_;
   string zmqNamecoindAddr_;
   uint32_t zmqTimeout_;
 

--- a/src/gbtmaker/GbtMakerMain.cc
+++ b/src/gbtmaker/GbtMakerMain.cc
@@ -128,6 +128,7 @@ int main(int argc, char **argv) {
     cfg.lookupValue("gbtmaker.rpcinterval", rpcCallInterval);
     gGbtMaker = new GbtMaker(
         cfg.lookup("bitcoind.zmq_addr"),
+        cfg.lookup("bitcoind.zmq_timeout"),
         cfg.lookup("bitcoind.rpc_addr"),
         cfg.lookup("bitcoind.rpc_userpwd"),
         cfg.lookup("kafka.brokers"),

--- a/src/nmcauxmaker/NMCAuxBlockMakerMain.cc
+++ b/src/nmcauxmaker/NMCAuxBlockMakerMain.cc
@@ -133,6 +133,7 @@ int main(int argc, char **argv) {
 
   gNMCAuxBlockMaker = new NMCAuxBlockMaker(
       cfg.lookup("namecoind.zmq_addr"),
+      cfg.lookup("namecoind.zmq_timeout"),
       cfg.lookup("namecoind.rpc_addr"),
       cfg.lookup("namecoind.rpc_userpwd"),
       cfg.lookup("kafka.brokers"),


### PR DESCRIPTION
When using ZMQ to receive hashblock notifications from nodes, it is possible that connection fails silently and gbtmaker/nmcauxmaker cannot receive notifications anymore. Now we can set a configurable zmq timeout and gbtmaker/nmcauxmaker will attempt reconnecting if nothing has been received in a period of the timeout.

The configuration item is `bitcoind.zmq_timeout` for gbtmaker and `namecoind.zmq_timeout` for nmcauxmaker. It is recommended to set it to longer than block time.